### PR TITLE
Build script

### DIFF
--- a/build-dev-env.sh
+++ b/build-dev-env.sh
@@ -18,3 +18,11 @@ lxc launch images:ubuntu/focal "${container_name}"
 sleep 10
 lxc file push ./build-script.sh "${container_name}/build-script.sh"
 lxc exec "${container_name}" -- bash /build-script.sh
+echo "Stopping ${container_name} to make an image from it"
+lxc stop "${container_name}"
+lxc publish "${container_name}" --alias mario-dev-env
+echo "A new image based on ${container_name} can be launched/initialized with either"
+echo " lxc launch mario-dev-env [optional name] or lxc init mario-dev-env [optional name]"
+echo
+echo "The container ${container_name} still exists and can also be used by just"
+echo " starting it with lxc start ${container_name}"

--- a/build-dev-env.sh
+++ b/build-dev-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+err () {
+  exit 1
+}
+
+trap err ERR
+
+if [ $# -ne 1 ]; then
+  echo "You need to supply a container name"
+  echo "Usage:"
+  echo "$0 <container name>"
+  exit 1
+else
+  container_name="${1}"
+fi
+
+lxc launch images:ubuntu/focal "${container_name}"
+sleep 10
+lxc file push ./build-script.sh "${container_name}/build-script.sh"
+lxc exec "${container_name}" -- bash /build-script.sh

--- a/build-script.sh
+++ b/build-script.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+err () {
+  exit 1
+}
+
+trap err ERR
+
+echo "Installing dependencies available from distro repositories"
+apt update
+apt install -y build-essential cmake python3.8 python3.8-dev libbz2-dev pkg-config capnproto libcapnp-dev zlib1g-dev xvfb python-opengl python3-pip git
+
+echo "Installing dependencies with pip"
+pip3 install torch tensorflow numpy~=1.19.2
+
+echo "Cloning git repos"
+git clone https://github.com/oblivia-simplex/retro
+git clone https://github.com/openai/baselines -b tf2
+
+echo "Installing lucca's fork of retrogym"
+pushd ~/retro/RetroGym
+pip3 install -e .
+popd
+
+echo "Installing a2c_ppo_acktr from MarioWM directory"
+pushd ~/retro/MarioWM
+pip3 install -e .
+popd
+
+echo "Installing baselines from own checkout"
+pushd ~/baselines
+pip3 install -e .
+popd
+

--- a/build-script.sh
+++ b/build-script.sh
@@ -19,6 +19,7 @@ git clone https://github.com/lejonet/baselines -b tf2
 echo "Installing lucca's fork of retrogym"
 pushd ~/retro/RetroGym
 pip3 install -e .
+python3 -m retro.import ./SMW
 popd
 
 echo "Installing a2c_ppo_acktr from MarioWM directory"

--- a/build-script.sh
+++ b/build-script.sh
@@ -14,7 +14,7 @@ pip3 install torch tensorflow numpy~=1.19.2
 
 echo "Cloning git repos"
 git clone https://github.com/oblivia-simplex/retro
-git clone https://github.com/openai/baselines -b tf2
+git clone https://github.com/lejonet/baselines -b tf2
 
 echo "Installing lucca's fork of retrogym"
 pushd ~/retro/RetroGym


### PR DESCRIPTION
It currently builds everything needed for both the MarioWM part and RetroGym parts, I've verified that doing
```
POKES=1 xvfb-run ~/retro/RetroGym/watch_snes_pc.py
```
works as it should, as in that it starts dumping all kinds of instructions and so. Equally so, doing 
```
xvfb-run python3 ~/retro/MarioWM/main.py
```
gets the error about data format, which iirc indicates that it at least works to start it, just that the data format has changed and the code needs to be fixed to account for that before we can actually know if it works or not.

Xvfb is ofc not ideal to run this in, as the opengl window for watch_snes_pc.py doesn't show up at all, but its all there is for doing it purely CLI. Next step would be to hook the container into the host X, but that is more a LXD config thing, than something that is done in the build script.